### PR TITLE
Fixes for C string issues such as #1

### DIFF
--- a/include/sap.h
+++ b/include/sap.h
@@ -31,7 +31,6 @@
 	#define ARG_LONGOPT 1
 	#define ARG_NORMAL 2
 	#define ARG_ERROR 3
-	#define ARG_EMPTY 4
 #endif
 
 /**
@@ -183,15 +182,9 @@ int _sap_check_arg_type(char *arg)
 		// unknown
 		else return ARG_ERROR;
 	}
-	// not flag
+	// normal string
 	else
-	{
-		// empty
-		if (arg[0] == '\0') return ARG_EMPTY;
-
-		// normal string
 		return ARG_NORMAL;
-	}
 }
 
 int sap_parse_args(SapConfig config, int argc, char **argv)

--- a/include/sap.h
+++ b/include/sap.h
@@ -196,6 +196,12 @@ int _sap_check_arg_type(char *arg)
 
 int sap_parse_args(SapConfig config, int argc, char **argv)
 {
+	// keep track of which tokens have been parsed
+	// we only update this for ARG_NORMAL arguments (since we want to keep track
+	// of which are positional and which are valued options
+	int parsed[argc]; // 0 = not parsed, 1 = parsed
+	for (int i = 0; i < argc; i++) parsed[i] = 0;
+
 	// set all arguments to not set
 	for (unsigned int i = 0; i < config.argcount; i++)
 	{
@@ -247,7 +253,7 @@ int sap_parse_args(SapConfig config, int argc, char **argv)
 											== ARG_NORMAL)
 									{
 										arg->value = argv[j + 1];
-										argv[j + 1] = "";
+										parsed[j + 1] = 1;
 									}
 									else // no value given
 									{
@@ -279,7 +285,7 @@ int sap_parse_args(SapConfig config, int argc, char **argv)
 									== ARG_NORMAL)
 								{
 									arg->value = argv[j + 1];
-									argv[j + 1] = "";
+									parsed[j + 1] = 1;
 								}
 							}
 							else
@@ -313,6 +319,7 @@ int sap_parse_args(SapConfig config, int argc, char **argv)
 				switch (_sap_check_arg_type(argv[j]))
 				{
 				case ARG_NORMAL:
+					if (parsed[j]) break; // this was a valued option
 					if (positionalsHit == positionalsHandled)
 					{
 						arg->value = argv[j];
@@ -323,7 +330,6 @@ int sap_parse_args(SapConfig config, int argc, char **argv)
 					{
 						positionalsHit++;
 					}
-						// all values for options should be ARG_EMPTY now
 					break;
 				case ARG_ERROR:
 					return 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,3 +4,6 @@ add_executable(cpptests src/cpptests.cpp)
 # include header files
 target_include_directories(ctests PRIVATE ../include)
 target_include_directories(cpptests PRIVATE ../include)
+
+# set debug mode for -g
+set(CMAKE_BUILD_TYPE Debug)

--- a/tests/src/ctests.c
+++ b/tests/src/ctests.c
@@ -4,6 +4,7 @@
  */
 
 #include <assert.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -119,6 +120,30 @@ SapConfig setup_test_config()
 }
 
 /**
+ * @brief Copies the contents of ..., an array of immutable strings, into argv,
+ * another array of strings but mutable. Each element of argv must be freed
+ * after use.
+ *
+ * @param argc length of argv and out
+ * @param argv array to output to
+ * @param ... array of immutable strings
+ */
+void copy_argv(int argc, char **argv, ...)
+{
+	va_list strings;
+	va_start(strings, argv);
+	for (int i = 0; i < argc; i++)
+	{
+		const char *next = va_arg(strings, const char *);
+		argv[i] = malloc(sizeof(char) * (strlen(next))); // +1 for \0
+		strcpy(argv[i], next);
+	}
+	va_end(strings);
+}
+
+#define FREE_ARGV(argc, argv) for (int i = 0; i < argc; i++) free(argv[i])
+
+/**
  * @brief Tests valued arguments with provided config
  *
  * @param config config
@@ -128,36 +153,49 @@ void test_value(SapConfig config)
 	printf("Testing valued options...\n");
 
 	printf("Testing simple value\n");
-	char *argv1[] = { "ctests", "-v", "value", "posarg", "posarg2" };
+	char *argv1[5];
+	copy_argv(5, argv1, "ctests", "-v", "value", "posarg", "posarg2");
 	assert(sap_parse_args(config, 5, argv1) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
+	FREE_ARGV(5, argv1);
 
 	printf("Testing multiple values\n");
-	char *argv2[] = { "ctests", "-v", "value", "-c", "cvalue", "posarg", "posarg2" };
+	char *argv2[7];
+	copy_argv(7, argv2, "ctests", "-v", "value", "-c", "cvalue", "posarg",
+		"posarg2");
 	assert(sap_parse_args(config, 7, argv2) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(config.arguments[4].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
 	assert(strcmp(config.arguments[4].value, "cvalue") == 0);
+	FREE_ARGV(7, argv2);
 
 	printf("Testing incorrect multiple shortopt\n");
-	char *argv3[] = { "ctests", "-vc", "value", "posarg", "posarg2" };
+	char *argv3[5];
+	copy_argv(5, argv3, "ctests", "-vc", "value", "posarg", "posarg2");
 	assert(sap_parse_args(config, 5, argv3) != 0);
+	FREE_ARGV(5, argv3);
 
 	printf("Testing value option followed by more options values\n");
-	char *argv4[] = { "ctests", "-v", "--cvalue", "posarg", "posarg2" };
+	char *argv4[5];
+	copy_argv(5, argv4, "ctests", "-v", "--cvalue", "posarg", "posarg2");
 	assert(sap_parse_args(config, 5, argv4) != 0);
+	FREE_ARGV(5, argv4);
 
 	printf("Testing longopt value\n");
-	char *argv5[] = { "ctests", "--value", "value", "posarg", "posarg2" };
+	char *argv5[5];
+	copy_argv(5, argv5, "ctests", "--value", "value", "posarg", "posarg2");
 	assert(sap_parse_args(config, 5, argv5) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
+	FREE_ARGV(5, argv5);
 
 	printf("Testing lack of required value\n");
-	char *argv6[] = { "ctests", "posarg", "--cvalue", "abc", "posarg2" };
+	char *argv6[5];
+	copy_argv(5, argv6, "ctests", "posarg", "--cvalue", "abc", "posarg2");
 	assert(sap_parse_args(config, 5, argv6) != 0);
+	FREE_ARGV(5, argv6);
 
 	printf("Value testing passed\n\n");
 }
@@ -172,7 +210,8 @@ void test_opt(SapConfig config)
 	printf("Testing options...\n");
 
 	printf("Testing setting of option\n");
-	char *argv1[] = { "ctests", "-v", "value", "posarg", "posarg2", "-a" };
+	char *argv1[6];
+	copy_argv(6, argv1, "ctests", "-v", "value", "posarg", "posarg2", "-a");
 	assert(sap_parse_args(config, 6, argv1) == 0);
 	assert(config.arguments[0].set == 0);
 	assert(config.arguments[1].set == 1);
@@ -181,9 +220,11 @@ void test_opt(SapConfig config)
 	assert(config.arguments[4].set == 0);
 	assert(config.arguments[5].set == 0);
 	assert(config.arguments[6].set == 1);
+	FREE_ARGV(6, argv1);
 
 	printf("Testing multiple options\n");
-	char *argv2[] = { "ctests", "-v", "value", "posarg", "posarg2", "-abh" };
+	char *argv2[6];
+	copy_argv(6, argv2, "ctests", "-v", "value", "posarg", "posarg2", "-abh");
 	assert(sap_parse_args(config, 6, argv2) == 0);
 	assert(config.arguments[0].set == 1);
 	assert(config.arguments[1].set == 1);
@@ -192,6 +233,7 @@ void test_opt(SapConfig config)
 	assert(config.arguments[4].set == 0);
 	assert(config.arguments[5].set == 1);
 	assert(config.arguments[6].set == 1);
+	FREE_ARGV(6, argv2);
 
 	printf("Options testing passed\n\n");
 }
@@ -206,28 +248,34 @@ void test_pos(SapConfig config)
 	printf("Testing positional arguments...\n");
 
 	printf("Testing order 1\n");
-	char *argv1[] = { "ctests", "-v", "value", "posarg", "posarg2" };
+	char *argv1[5];
+	copy_argv(5, argv1, "ctests", "-v", "value", "posarg", "posarg2");
 	assert(sap_parse_args(config, 5, argv1) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
 	assert(strcmp(config.arguments[1].value, "posarg") == 0);
 	assert(strcmp(config.arguments[6].value, "posarg2") == 0);
+	FREE_ARGV(5, argv1);
 
 	printf("Testing order 2\n");
-	char *argv2[] = { "ctests", "posarg", "-v", "value", "posarg2" };
+	char *argv2[5];
+	copy_argv(5, argv2, "ctests", "posarg", "-v", "value", "posarg2");
 	assert(sap_parse_args(config, 5, argv2) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
 	assert(strcmp(config.arguments[1].value, "posarg") == 0);
 	assert(strcmp(config.arguments[6].value, "posarg2") == 0);
+	FREE_ARGV(5, argv2);
 
 	printf("Testing order 3\n");
-	char *argv3[] = { "ctests", "posarg", "posarg2", "-v", "value" };
+	char *argv3[5];
+	copy_argv(5, argv3, "ctests", "posarg", "posarg2", "-v", "value");
 	assert(sap_parse_args(config, 5, argv3) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
 	assert(strcmp(config.arguments[1].value, "posarg") == 0);
 	assert(strcmp(config.arguments[6].value, "posarg2") == 0);
+	FREE_ARGV(5, argv3);
 
 	printf("Positional arguments testing passed\n\n");
 }
@@ -237,20 +285,24 @@ void test_nonalpha(SapConfig config)
 	printf("Testing nonalpha positional and valued arguments...\n");
 
 	printf("Testing positional arguments\n");
-	char *argv1[] = { "ctests", "123abc", "abcdefg", "-v", "value" };
+	char *argv1[5];
+	copy_argv(5, argv1, "ctests", "123abc", "abcdefg", "-v", "value");
 	assert(sap_parse_args(config, 5, argv1) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "value") == 0);
 	assert(strcmp(config.arguments[1].value, "123abc") == 0);
 	assert(strcmp(config.arguments[6].value, "abcdefg") == 0);
+	FREE_ARGV(5, argv1);
 
 	printf("Testing valued option\n");
-	char *argv2[] = { "ctests", "123abc", "abcdefg", "-v", "123" };
+	char *argv2[5];
+	copy_argv(5, argv2, "ctests", "123abc", "abcdefg", "-v", "123");
 	assert(sap_parse_args(config, 5, argv2) == 0);
 	assert(config.arguments[2].set == 1);
 	assert(strcmp(config.arguments[2].value, "123") == 0);
 	assert(strcmp(config.arguments[1].value, "123abc") == 0);
 	assert(strcmp(config.arguments[6].value, "abcdefg") == 0);
+	FREE_ARGV(5, argv2);
 }
 
 int main()


### PR DESCRIPTION
This fixes #1 as well as making sure `sap.h` does not messily edit `argv`, which led to some issues with `(char *)` pointers.